### PR TITLE
Minor optimizations on modulo and prefetching for tConvolve gridding and degridding

### DIFF
--- a/attic/tConvolveMIC/tConvolveMIC.cc
+++ b/attic/tConvolveMIC/tConvolveMIC.cc
@@ -125,9 +125,9 @@ int gridKernelMIC(const Value* data, const size_t dataSize,
                 int gind = iu[dind] + gSize * iv[dind] - support;
                 // The Convoluton function point from which we offset
                 int cind = cOffset[dind];
-                int row = iv[dind];
+                int row = iv[dind] % nthreads;
                 for (int suppv = 0; suppv < sSize; suppv++) {
-                    if (row % nthreads == tid) {
+                    if (row == tid) {
 #ifdef USEBLAS
                         cblas_caxpy(sSize, &data[dind], &C[cind], 1, &grid[gind], 1);
 #else
@@ -143,6 +143,7 @@ int gridKernelMIC(const Value* data, const size_t dataSize,
                     gind += gSize;
                     cind += sSize;
                     row++;
+                    row = (row >= nthreads) ? 0 : row;
                 }
             }
         } // End omp parallel

--- a/attic/tConvolveOMP/tConvolveOMP.cc
+++ b/attic/tConvolveOMP/tConvolveOMP.cc
@@ -154,9 +154,9 @@ int gridKernelOMP(const std::vector<Value>& data, const int support,
             int gind = iu[dind] + gSize * iv[dind] - support;
             // The Convoluton function point from which we offset
             int cind = cOffset[dind];
-            int row = iv[dind];
+            int row = iv[dind] % nthreads;
             for (int suppv = 0; suppv < sSize; suppv++) {
-                if (row % nthreads == tid) {
+                if (row == tid) {
 #ifdef USEBLAS
                     CAXPY(sSize, &data[dind], &C[cind], 1, &grid[gind], 1);
 #else
@@ -172,6 +172,7 @@ int gridKernelOMP(const std::vector<Value>& data, const int support,
                 gind += gSize;
                 cind += sSize;
                 row++;
+                row = (row >= nthreads) ? 0 : row;
             }
         }
     } // End omp parallel

--- a/attic/tConvolveOMP/tConvolveOMP.cc
+++ b/attic/tConvolveOMP/tConvolveOMP.cc
@@ -138,6 +138,7 @@ void gridKernel(const std::vector<Value>& data, const int support,
     }
 }
 
+#pragma GCC optimize("prefetch-loop-arrays")
 int gridKernelOMP(const std::vector<Value>& data, const int support,
         const std::vector<Value>& C, const std::vector<int>& cOffset,
         const std::vector<int>& iu, const std::vector<int>& iv,
@@ -179,6 +180,7 @@ int gridKernelOMP(const std::vector<Value>& data, const int support,
 
     return omp_get_max_threads();
 }
+#pragma GCC optimize("no-prefetch-loop-arrays")
 
 // Perform degridding
 void degridKernel(const std::vector<Value>& grid, const int gSize, const int support,


### PR DESCRIPTION
The following two patches improve performance on modern x86 systems. The modulo operating optimization shows improvements of +10% and the cache prefetching adds another 1%-2% improvement depending on cache size and memory speed and number of concurrent threads being used.